### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,18 +5,18 @@
 ####################################################
 #   Classes (KEYWORD1)
 ####################################################
-PWFusion_MAX31855_TC							KEYWORD1
+PWFusion_MAX31855_TC	KEYWORD1
 
 
 ####################################################
 #   Functions (KEYWORD2)
 ####################################################
-SPIbus_Init								KEYWORD2
-MAX31855_update							KEYWORD2
-TCcorrection							KEYWORD2
+SPIbus_Init	KEYWORD2
+MAX31855_update	KEYWORD2
+TCcorrection	KEYWORD2
 
 ####################################################
 #   Constants (LITERAL1)
 ####################################################
-T_voltage								LITERAL1
-J_voltage								LITERAL1
+T_voltage	LITERAL1
+J_voltage	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords